### PR TITLE
Add basic WebGPU viewer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "id_game_config",
     "id_core",
     "id_viewer",
+    "id_viewer_web",
     "third_party/egui_console",
 ]
 

--- a/id_viewer_web/Cargo.toml
+++ b/id_viewer_web/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "id-viewer-web"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+id-core = { path = "../id_core" }
+id-map-format = { path = "../id_map_format" }
+
+winit = "0.29.15"
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
+web-sys = { version = "0.3", features = ["Window", "Document", "HtmlCanvasElement", "File", "FileList", "FileReader", "Blob", "Url", "Element", "HtmlInputElement", "EventTarget", "DragEvent", "DataTransfer", "DataTransferItemList", "DataTransferItem"] }
+pollster = "0.3"
+ultraviolet = { workspace = true }
+js-sys = "0.3"

--- a/id_viewer_web/index.html
+++ b/id_viewer_web/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+<title>Id Viewer Web</title>
+<style>
+html, body { margin:0; padding:0; width:100%; height:100%; overflow:hidden; }
+#canvas { width:100%; height:100%; display:block; }
+</style>
+</head>
+<body>
+<canvas id="canvas"></canvas>
+<script type="module">
+import init, { run } from './pkg/id_viewer_web.js';
+init().then(() => run('canvas'));
+</script>
+</body>
+</html>

--- a/id_viewer_web/src/lib.rs
+++ b/id_viewer_web/src/lib.rs
@@ -1,0 +1,126 @@
+mod winit_system;
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_futures::spawn_local;
+use winit::platform::web::WindowBuilderExtWebSys;
+use winit::dpi::PhysicalSize;
+use winit::{event::Event, event::WindowEvent, event_loop::{ControlFlow, EventLoop}, window::WindowBuilder};
+
+use id_core::world::World;
+use id_map_format::Wad;
+use id_core::renderer::{debug_window, overlay_window, WindowRunner};
+use id_core::renderer::{egui_window, main_user_context, main_window};
+use id_core::Stopwatch;
+use ultraviolet::UVec2;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+fn create_runner(window: &winit::window::Window, wad_bytes: Vec<u8>) -> WindowRunner<'static, impl id_core::renderer::helpers::window::UserContext> {
+    let wad = Wad::new(wad_bytes).expect("Failed to parse IWAD");
+    let world = World::new(wad, vec![], "E1M1").expect("Failed to create world");
+    let user_context = main_user_context(Rc::new(RefCell::new(world)));
+    let window_setup = egui_window(overlay_window((main_window(), debug_window())));
+    let size = window.inner_size();
+    pollster::block_on(WindowRunner::from_system_window(
+        window,
+        UVec2 { x: size.width, y: size.height },
+        user_context,
+        window_setup,
+    )).expect("Failed to create WindowRunner")
+}
+
+#[wasm_bindgen]
+pub fn run(canvas_id: &str) {
+    console_error_panic_hook::set_once();
+
+    let window = web_sys::window().expect("no global `window`");
+    let document = window.document().expect("no document on window");
+    let canvas = document
+        .get_element_by_id(canvas_id)
+        .expect("Canvas not found")
+        .dyn_into::<web_sys::HtmlCanvasElement>()
+        .unwrap();
+
+    let event_loop = EventLoop::new();
+    let winit_window = WindowBuilder::new()
+        .with_canvas(Some(canvas))
+        .with_inner_size(PhysicalSize::new(800u32, 600u32))
+        .build(&event_loop)
+        .unwrap();
+
+    use wasm_bindgen::JsCast;
+    let body = document.body().unwrap();
+    let drop_zone = document.create_element("div").unwrap();
+    drop_zone.set_attribute("style", "position:absolute;left:0;top:0;right:0;bottom:0;border:2px dashed #888;").unwrap();
+    body.append_child(&drop_zone).unwrap();
+    drop_zone.set_inner_html("Drop WAD file here");
+
+    let wad_bytes = Rc::new(RefCell::new(None));
+    {
+        let wad_bytes_clone = wad_bytes.clone();
+        let closure = Closure::<dyn FnMut(web_sys::DragEvent)>::wrap(Box::new(move |e| {
+            e.prevent_default();
+            if let Some(items) = e.data_transfer().and_then(|dt| dt.files()) {
+                if let Some(file) = items.get(0) {
+                    let fr = web_sys::FileReader::new().unwrap();
+                    let fr_c = fr.clone();
+                    let wad_bytes_c = wad_bytes_clone.clone();
+                    let onload = Closure::<dyn FnMut(_)>::wrap(Box::new(move |_| {
+                        let array = js_sys::Uint8Array::new(&fr_c.result().unwrap());
+                        let mut buf = vec![0u8; array.length() as usize];
+                        array.copy_to(&mut buf[..]);
+                        *wad_bytes_c.borrow_mut() = Some(buf);
+                    }));
+                    fr.set_onload(Some(onload.as_ref().unchecked_ref()));
+                    onload.forget();
+                    fr.read_as_array_buffer(&file).unwrap();
+                }
+            }
+        }));
+        drop_zone.add_event_listener_with_callback("drop", closure.as_ref().unchecked_ref()).unwrap();
+        closure.forget();
+        let closure = Closure::<dyn FnMut(web_sys::DragEvent)>::wrap(Box::new(|e| e.prevent_default()));
+        drop_zone.add_event_listener_with_callback("dragover", closure.as_ref().unchecked_ref()).unwrap();
+        closure.forget();
+    }
+
+    spawn_local(async move {
+        loop {
+            if let Some(bytes) = wad_bytes.borrow_mut().take() {
+                let mut runner = create_runner(&winit_window, bytes);
+                let mut stopwatch = Stopwatch::new();
+                let tick_rate_ms = 1000/60;
+                event_loop.set_control_flow(ControlFlow::Poll);
+                event_loop.run(move |event, elwt| {
+                    elwt.set_control_flow(ControlFlow::Poll);
+                    match event {
+                        Event::AboutToWait => {},
+                        Event::WindowEvent { event, .. } => match event {
+                            WindowEvent::Resized(size) => {
+                                runner.handle_event(winit_system::to_system_event(WindowEvent::Resized(size))).unwrap();
+                            }
+                            _ => {
+                                if let Some(sys) = winit_system::to_system_event(event) {
+                                    runner.handle_event(sys).unwrap();
+                                }
+                            }
+                        },
+                        Event::RedrawEventsCleared => {
+                            let delta = stopwatch.lap();
+                            let delta_ticks = delta.as_millis()/tick_rate_ms;
+                            stopwatch.rewind(std::time::Duration::from_millis((delta.as_millis()%tick_rate_ms) as u64));
+                            if delta_ticks>0 {
+                                runner.think(std::time::Duration::from_millis((delta_ticks*tick_rate_ms) as u64)).unwrap();
+                            }
+                            runner.draw(delta).unwrap();
+                        }
+                        Event::LoopExiting => { elwt.set_control_flow(ControlFlow::Exit); },
+                        _ => {}
+                    }
+                });
+                break;
+}
+            gloo_timers::future::TimeoutFuture::new(100).await;
+        }
+    });
+}
+

--- a/id_viewer_web/src/winit_system.rs
+++ b/id_viewer_web/src/winit_system.rs
@@ -1,0 +1,43 @@
+use winit::event::{KeyboardInput, ElementState, MouseButton, MouseScrollDelta, WindowEvent};
+use id_core::renderer::system::{SystemEvent, SystemMouseButton, SystemMod};
+use id_core::renderer::system::parse_keymap_from_usb;
+
+pub fn to_system_event(event: WindowEvent) -> Option<SystemEvent> {
+    match event {
+        WindowEvent::KeyboardInput { input: KeyboardInput { scancode, state, .. }, .. } => {
+            if let Ok(keymap) = parse_keymap_from_usb(scancode as u16) {
+                let keycode = keymap.code?;
+                let mods = keymap.modifier.unwrap_or(SystemMod::empty());
+                match state {
+                    ElementState::Pressed => Some(SystemEvent::KeyDown { keycode, mods }),
+                    ElementState::Released => Some(SystemEvent::KeyUp { keycode, mods }),
+                }
+            } else { None }
+        }
+        WindowEvent::ReceivedCharacter(c) => Some(SystemEvent::Text { text: c.to_string() }),
+        WindowEvent::CursorMoved { position, .. } => {
+            Some(SystemEvent::MouseMotion { x: position.x as i32, y: position.y as i32, xrel: 0, yrel: 0 })
+        }
+        WindowEvent::MouseInput { state, button, .. } => {
+            let btn = match button {
+                MouseButton::Left => SystemMouseButton::Left,
+                MouseButton::Middle => SystemMouseButton::Middle,
+                MouseButton::Right => SystemMouseButton::Right,
+                _ => return None,
+            };
+            match state {
+                ElementState::Pressed => Some(SystemEvent::MouseButtonDown { mouse_btn: btn }),
+                ElementState::Released => Some(SystemEvent::MouseButtonUp { mouse_btn: btn }),
+            }
+        }
+        WindowEvent::MouseWheel { delta, .. } => {
+            let (x, y) = match delta {
+                MouseScrollDelta::LineDelta(x, y) => (x as i32, y as i32),
+                MouseScrollDelta::PixelDelta(p) => (p.x as i32, p.y as i32),
+            };
+            Some(SystemEvent::MouseWheel { x, y })
+        }
+        WindowEvent::Resized(size) => Some(SystemEvent::SizeChanged { width: size.width, height: size.height }),
+        _ => None,
+    }
+}


### PR DESCRIPTION
## Summary
- add `id_viewer_web` with WebGPU/WASM support
- expose a drag-and-drop web UI

## Testing
- `cargo check --workspace` *(fails: could not compile `wgpu-pp`)*

------
https://chatgpt.com/codex/tasks/task_e_685494ad932c832a827eb1b785d050ff